### PR TITLE
docs: review and edits of PR #2510 docs: manage workspaces with kubectl 

### DIFF
--- a/modules/end-user-guide/pages/managing-workspaces-with-apis.adoc
+++ b/modules/end-user-guide/pages/managing-workspaces-with-apis.adoc
@@ -7,14 +7,14 @@
 [id="managing-workspaces-with-apis"]
 = Managing workspaces with {orch-name} APIs
 
-On a {platforms-name} cluster, {prod-short} workspaces are represented as `DevWorkspace` custom resources of the same name.
-As a result, if there is a workspace named `my-workspace` in the {prod-short} dashboard, there is a `DevWorkspace` named `my-workspace` in the user's {orch-namespace} on the {orch-name} cluster.
+On the {platforms-name} cluster, {prod-short} workspaces are represented as `DevWorkspace` custom resources of the same name.
+As a result, if there is a workspace named `my-workspace` in the {prod-short} dashboard, there is a corresponding `DevWorkspace` named `my-workspace` in the user's {orch-namespace} on the cluster.
 
-Since `DevWorkspaces` on the cluster represent {prod-short} workspaces, this allows managing {prod-short} workspaces using {orch-name} APIs with clients such as {orch-cli}.
+Because each `DevWorkspace` custom resource on the cluster represents a {prod-short} workspace, you can manage {prod-short} workspaces by using {orch-name} APIs with clients such as the command-line {orch-cli}.
 
-Each `DevWorkspace` contains details derived from the workspace project's devfile, such as workspace container configurations and devfile commands.
+Each `DevWorkspace` contains details derived from the devfile of the Git repository cloned in the workspace. For example, a devfile might provide devfile commands and workspace container configurations.
 
-Each `DevWorkspace` also references a `DevWorkspaceTemplate` custom resource using the `spec.contributions` field, which contains details about the editor for the workspace.
+Each `DevWorkspace` also references a `DevWorkspaceTemplate` custom resource using the `spec.contributions` field, which contains details about the editor to be loaded in the workspace.
 
 To manage a workspace with {orch-name} APIs, you must determine the workspace `NAME` and the `NAMESPACE` it is located in.
 

--- a/modules/end-user-guide/pages/managing-workspaces-with-apis.adoc
+++ b/modules/end-user-guide/pages/managing-workspaces-with-apis.adoc
@@ -7,16 +7,14 @@
 [id="managing-workspaces-with-apis"]
 = Managing workspaces with {orch-name} APIs
 
-On the {platforms-name} cluster, {prod-short} workspaces are represented as `DevWorkspace` custom resources of the same name.
-As a result, if there is a workspace named `my-workspace` in the {prod-short} dashboard, there is a corresponding `DevWorkspace` named `my-workspace` in the user's {orch-namespace} on the cluster.
+On your organization's {orch-name} cluster, {prod-short} workspaces are represented as `DevWorkspace` custom resources of the same name.
+As a result, if there is a workspace named `my-workspace` in the {prod-short} dashboard, there is a corresponding `DevWorkspace` custom resource named `my-workspace` in the user's {orch-namespace} on the cluster.
 
-Because each `DevWorkspace` custom resource on the cluster represents a {prod-short} workspace, you can manage {prod-short} workspaces by using {orch-name} APIs with clients such as the command-line {orch-cli}.
+Because each `DevWorkspace` custom resource on the cluster represents a {prod-short} workspace, you can manage {prod-short} workspaces by using {orch-name} APIs with clients such as the command-line `{orch-cli}`.
 
-Each `DevWorkspace` contains details derived from the devfile of the Git repository cloned in the workspace. For example, a devfile might provide devfile commands and workspace container configurations.
+Each `DevWorkspace` contains details derived from the devfile of the Git repository cloned for the workspace. For example, a devfile might provide devfile commands and workspace container configurations.
 
-Each `DevWorkspace` also references a `DevWorkspaceTemplate` custom resource using the `spec.contributions` field, which contains details about the editor to be loaded in the workspace.
-
-To manage a workspace with {orch-name} APIs, you must determine the workspace `NAME` and the `NAMESPACE` it is located in.
+Each `DevWorkspace` custom resource also references a `DevWorkspaceTemplate` custom resource using the `spec.contributions` field, which provides details about the IDE for the workspace.
 
 include::partial$proc_listing-workspaces.adoc[leveloffset=+1]
 

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -152,7 +152,7 @@ components:
 +
 TIP: For more details, see the link:https://devfile.io/docs/2.1.0/what-is-a-devfile[devfile v2 documentation].
 
-. Create a `DevWorkspace` custom resource definition that incorporates the copied devfile contents from the previous step.
+. Create a `DevWorkspace` custom resource definition, pasting the devfile contents from the previous step under the `spec.template` field.
 +
 .A `DevWorkspace` custom resource definition
 ====

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -2,30 +2,50 @@
 [id="creating-workspaces"]
 = Creating workspaces
 
-It is recommended however, for users to create workspaces using the {prod-short} Dashboard instead of using {orch-name} APIs to manually create `DevWorkspace` and `DevWorkspaceTemplate` custom resources.
+Because workspaces on the {orch-name} cluster are represented by custom resources, and if your use case does not permit use of the {prod-short} dashboard, you can instead create workspaces with {orch-name} APIs by applying custom resources to the cluster.
 
-This is because creating workspaces using the {prod-short} Dashboard helps {prod-short} and its components convert the workspace project's devfile to `DevWorkspace` and `DevWorkspaceTemplate` custom resources on the cluster.
+[NOTE]
+====
 
-Creating workspaces using the {prod-short} dashboard allows {prod-short} to make the following additions to the newly created `DevWorkspaces`:
+Using the {prod-short} dashboard is the default way to create workspaces because {prod-short} and its components automatically convert the target Git repository's devfile into the `DevWorkspace` and `DevWorkspaceTemplate` custom resources on the cluster with the following configuration benefits:
 
 * Recognition of configurations in `spec.devEnvironments` specified in the `CheCluster` custom resource including:
-** persistent storage strategy specified with `devEnvironments.storage`
-** default editor specified with `devEnvironments.defaultEditor`
-** default plugins specified with `devEnvironments.defaultPlugins`
-** container build configuration specified with `devEnvironments.containerBuildConfiguration`
+** Persistent storage strategy specified with `devEnvironments.storage`
+** Default IDE specified with `devEnvironments.defaultEditor`
+** Default plugins specified with `devEnvironments.defaultPlugins`
+** Container build configuration specified with `devEnvironments.containerBuildConfiguration`
 * Recognition of the `DevWorkspaceOperatorConfig` configuration managed by {prod-short}
 
-Because workspaces on the {orch-name} cluster are represented by custom resources, you can create workspaces with {orch-name} APIs by applying custom resources to the cluster.
+====
 
 .Prerequisites
 
-* An active `{orch-cli}` session with permissions to create `DevWorkspace` and `DevWorkspaceTemplate` resources in your {orch-namespace} on the {orch-name} cluster. See {orch-cli-link}.
+* An active `{orch-cli}` session with permissions to create `DevWorkspace` and `DevWorkspaceTemplate` resources in your {orch-namespace} on the cluster. See {orch-cli-link}.
 
-NOTE: For admins creating workspaces for users, the `DevWorkspace` and `DevWorkspaceTemplate` custom resources should be created in a user namespace that is provisioned by {prod-short} or provisioned by the admin. See xref:administration-guide:configuring-namespace-provisioning.adoc[].
+* You know the relevant {prod-short} user namespace on the cluster.
++
+TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your {prod-short} user namespace as `name`.
+
+* You are on the {prod-short} user namespace on the cluster.
++
+[TIP]
+====
+On OpenShift:
+
+* You can use the `oc` command-line tool to check your current namespace:
++
+`$ oc project`
+
+* You can switch to your {prod-short} user namespace on a command line if needed:
++
+`$ oc project __<user_namespace>__`
+====
++
+NOTE: {prod-short} administrators who intend to create workspaces for other users must create the `DevWorkspace` and `DevWorkspaceTemplate` custom resources in a user namespace that is provisioned by {prod-short} or by the administrator. See xref:administration-guide:configuring-namespace-provisioning.adoc[].
 
 .Procedure
 
-. Create a `DevWorkspaceTemplate` for the editor.
+. Create a `DevWorkspaceTemplate` custom resource for the selected IDE.
 +
 .Creating a `DevWorkspaceTemplate` named `che-code` for the link:https://github.com/microsoft/vscode[Microsoft Visual Studio Code - Open Source] IDE
 ====
@@ -35,7 +55,7 @@ apiVersion: workspace.devfile.io/v1alpha2
 kind: DevWorkspaceTemplate
 metadata:
   name: che-code#<1>
-  namespace: __<user_{orch-namespace}>__#<2>
+  namespace: user1-dev#<2>
 spec:
   commands:
     - apply:
@@ -72,7 +92,7 @@ spec:
           - name: checode
             path: /checode
         memoryLimit: 1024Mi
-        image: 'quay.io/che-incubator/che-code:insiders' # no-op ignored image
+        image: 'quay.io/che-incubator/che-code:insiders'
         endpoints:
           - attributes:
               cookiesAuthEnabled: true
@@ -113,17 +133,16 @@ spec:
     preStart:
       - init-container-command
 ----
-<1> Name of the `DevWorkspaceTemplate`. This name will be used to reference the `DevWorkspaceTemplate` within the `DevWorkspace`.
-<2> Target {orch-namespace} for the new workspace.
+<1> Name of the `DevWorkspaceTemplate` custom resource. This name will be used to reference the `DevWorkspaceTemplate` custom resource within the `DevWorkspace` custom resource.
+<2> User namespace, which is the target {orch-namespace} for the new workspace.
 ====
 
-. To prepare the `DevWorkspace` custom resource, copy the contents of a project Devfile.
+. To prepare the `DevWorkspace` custom resource, copy the contents of the target Git repository's devfile.
 +
-.Copied devfile contents
+.Copied devfile contents with `schemaVersion: 2.1.0`
 ====
 [source,yaml,subs="+quotes,+attributes"]
 ----
-schemaVersion: 2.1.0    
 components:
   - name: tooling-container
     container:
@@ -133,9 +152,9 @@ components:
 +
 TIP: For more details, see the link:https://devfile.io/docs/2.1.0/what-is-a-devfile[devfile v2 documentation].
 
-. Use the devfile to create a `DevWorkspace` definition.
+. Create a `DevWorkspace` custom resource definition that incorporates the copied devfile contents from the previous step.
 +
-.Example title
+.A `DevWorkspace` custom resource definition
 ====
 [source,yaml,subs="+quotes,+attributes"]
 ----
@@ -143,11 +162,11 @@ kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
   name: my-devworkspace#<1>
-  namespace: __<user_{orch-namespace}>__#<2>
+  namespace: user1-dev#<2>
 spec:
   started: true#<3>
   contributions:#<4>
-    - name: editor
+    - name: IDE
       kubernetes:
         name: che-code#<5>
   template:
@@ -161,18 +180,18 @@ spec:
         container:
           image: quay.io/devfile/universal-developer-image:ubi8-latest
 ----
-<1> Name of `DevWorkspace` resource. This is will be the name of the new workspace.
-<2> Target {orch-namespace} for the new workspace.
-<3> Determines whether the workspace should be started upon creating the `DevWorkspace` resource.
-<4> Reference to the editor's `DevWorkspaceTemplate`.
-<5> Name of the editor's `DevWorkspaceTemplate` from the previous step.
-<6> Details about the Git project to clone upon workspace startup. The Git project that will be cloned for this example is https://github.com/eclipse-che/che-docs.
+<1> Name of the `DevWorkspace` custom resource. This is will be the name of the new workspace.
+<2> User namespace, which is the target {orch-namespace} for the new workspace.
+<3> Determines whether the workspace must be started when the `DevWorkspace` custom resource is created.
+<4> Reference to the `DevWorkspaceTemplate` custom resource of the selected IDE.
+<5> Name of the `DevWorkspaceTemplate` custom resource from the previous step.
+<6> Details about the Git repository to clone into the workspace when it starts.
 <7> List of components such as workspace containers and volume components.
 ====
 
 . Apply the `DevWorkspace` custom resource to the cluster. 
 
-. Verify that the workspace is starting by checking the `PHASE` status of the `DevWorkspace`.
+. Verify that the workspace is starting by checking the *PHASE* status of the `DevWorkspace`.
 +
 [subs="+quotes,attributes"]
 ----
@@ -188,9 +207,7 @@ user1-dev	     my-devworkspace       workspacedf64e4a492cd4701   Starting   Wait
 ----
 ====
 
-. When the workspace starts with the *PHASE* status *Running*, open the workspace by either way:
-** Visit the URL provided in the `INFO` section of the output from `{orch-cli} get devworkspaces`.
-** Open the workspace from the {prod-short} dashboard.
+. When the workspace has successfully started, its *PHASE* status changes to *Running* in the output of the `{orch-cli} get devworkspaces` command.
 +
 .Output
 ====
@@ -200,3 +217,8 @@ NAMESPACE            NAME                  DEVWORKSPACE ID             PHASE    
 user1-dev	     my-devworkspace       workspacedf64e4a492cd4701   Running    https://url-to-workspace.com
 ----
 ====
++
+You can then open the workspace by using one of these options:
++
+** Visit the URL provided in the `INFO` section of the output of the `{orch-cli} get devworkspaces` command.
+** Open the workspace from the {prod-short} dashboard.

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -2,7 +2,7 @@
 [id="creating-workspaces"]
 = Creating workspaces
 
-Because workspaces on the {orch-name} cluster are represented by custom resources, and if your use case does not permit use of the {prod-short} dashboard, you can instead create workspaces with {orch-name} APIs by applying custom resources to the cluster.
+If your use case does not permit use of the {prod-short} dashboard, you can create workspaces with {orch-name} APIs by applying custom resources to the cluster.
 
 [NOTE]
 ====

--- a/modules/end-user-guide/partials/proc_creating-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_creating-workspaces.adoc
@@ -2,13 +2,11 @@
 [id="creating-workspaces"]
 = Creating workspaces
 
-Since workspaces on the {orch-name} cluster are represented by custom resources, it is possible to create workspaces with {orch-name} APIs by applying custom resources to the cluster.
-
 It is recommended however, for users to create workspaces using the {prod-short} Dashboard instead of using {orch-name} APIs to manually create `DevWorkspace` and `DevWorkspaceTemplate` custom resources.
 
 This is because creating workspaces using the {prod-short} Dashboard helps {prod-short} and its components convert the workspace project's devfile to `DevWorkspace` and `DevWorkspaceTemplate` custom resources on the cluster.
 
-Creating workspaces using the {prod-short} Dashboard allows {prod-short} to make the following additions to the newly created `DevWorkspaces`:
+Creating workspaces using the {prod-short} dashboard allows {prod-short} to make the following additions to the newly created `DevWorkspaces`:
 
 * Recognition of configurations in `spec.devEnvironments` specified in the `CheCluster` custom resource including:
 ** persistent storage strategy specified with `devEnvironments.storage`
@@ -16,6 +14,8 @@ Creating workspaces using the {prod-short} Dashboard allows {prod-short} to make
 ** default plugins specified with `devEnvironments.defaultPlugins`
 ** container build configuration specified with `devEnvironments.containerBuildConfiguration`
 * Recognition of the `DevWorkspaceOperatorConfig` configuration managed by {prod-short}
+
+Because workspaces on the {orch-name} cluster are represented by custom resources, you can create workspaces with {orch-name} APIs by applying custom resources to the cluster.
 
 .Prerequisites
 
@@ -25,15 +25,17 @@ NOTE: For admins creating workspaces for users, the `DevWorkspace` and `DevWorks
 
 .Procedure
 
-. Create a `DevWorkspaceTemplate` for the editor. The example below creates a `DevWorkspaceTemplate` named `che-code` for the Che-Code Visual Studio Code editor.
+. Create a `DevWorkspaceTemplate` for the editor.
 +
+.Creating a `DevWorkspaceTemplate` named `che-code` for the link:https://github.com/microsoft/vscode[Microsoft Visual Studio Code - Open Source] IDE
+====
 [source,yaml,subs="+quotes,+attributes"]
 ----
 apiVersion: workspace.devfile.io/v1alpha2
 kind: DevWorkspaceTemplate
 metadata:
-  name: che-code <1>
-  namespace: __<user_{orch-namespace}>__ <2>
+  name: che-code#<1>
+  namespace: __<user_{orch-namespace}>__#<2>
 spec:
   commands:
     - apply:
@@ -113,8 +115,12 @@ spec:
 ----
 <1> Name of the `DevWorkspaceTemplate`. This name will be used to reference the `DevWorkspaceTemplate` within the `DevWorkspace`.
 <2> Target {orch-namespace} for the new workspace.
-. To prepare the `DevWorkspace` custom resource, copy the contents of a project Devfile. The example used for this procedure is the following Devfile:
+====
+
+. To prepare the `DevWorkspace` custom resource, copy the contents of a project Devfile.
 +
+.Copied devfile contents
+====
 [source,yaml,subs="+quotes,+attributes"]
 ----
 schemaVersion: 2.1.0    
@@ -123,31 +129,34 @@ components:
     container:
       image: quay.io/devfile/universal-developer-image:ubi8-latest
 ----
+====
 +
-For more details about Devfiles, see the link:https://devfile.io/docs/2.1.0/what-is-a-devfile[Devfile v2 documentation].
+TIP: For more details, see the link:https://devfile.io/docs/2.1.0/what-is-a-devfile[devfile v2 documentation].
 
-. Use the Devfile to create a `DevWorkspace` definition.
+. Use the devfile to create a `DevWorkspace` definition.
 +
+.Example title
+====
 [source,yaml,subs="+quotes,+attributes"]
 ----
 kind: DevWorkspace
 apiVersion: workspace.devfile.io/v1alpha2
 metadata:
-  name: my-devworkspace <1>
-  namespace: __<user_{orch-namespace}>__ <2>
+  name: my-devworkspace#<1>
+  namespace: __<user_{orch-namespace}>__#<2>
 spec:
-  started: true <3>
-  contributions: <4>
+  started: true#<3>
+  contributions:#<4>
     - name: editor
       kubernetes:
-        name: che-code <5>
+        name: che-code#<5>
   template:
-    projects: <6>
+    projects:#<6>
       - name: my-project-name
         git:
           remotes:
             origin: https://github.com/eclipse-che/che-docs
-    components: <7>
+    components:#<7>
       - name: tooling-container
         container:
           image: quay.io/devfile/universal-developer-image:ubi8-latest
@@ -159,20 +168,35 @@ spec:
 <5> Name of the editor's `DevWorkspaceTemplate` from the previous step.
 <6> Details about the Git project to clone upon workspace startup. The Git project that will be cloned for this example is https://github.com/eclipse-che/che-docs.
 <7> List of components such as workspace containers and volume components.
-. Apply the `DevWorkspace` to the cluster. 
-. Confirm that the workspace is starting by referring to the `PHASE` status of the `DevWorkspace`.
+====
+
+. Apply the `DevWorkspace` custom resource to the cluster. 
+
+. Verify that the workspace is starting by checking the `PHASE` status of the `DevWorkspace`.
 +
 [subs="+quotes,attributes"]
 ----
 $ {orch-cli} get devworkspaces -n __<user_{orch-namespace}>__  --watch
-
-NAMESPACE            NAME                  DEVWORKSPACE ID             PHASE      INFO
-__<user_{orch-namespace}>__   my-devworkspace       workspacedf64e4a492cd4701   Starting   Waiting for workspace deployment
 ----
-. Once the workspace starts, the workspace can be opened by accessing the URL provided in the `INFO` section of the output from `{orch-cli} get devworkspaces`, or by accessing the workspace from the {prod-short} Dashboard.
 +
+.Output
+====
 [subs="+quotes,attributes"]
 ----
 NAMESPACE            NAME                  DEVWORKSPACE ID             PHASE      INFO
-__<user_{orch-namespace}>__   my-devworkspace       workspacedf64e4a492cd4701   Running    https://url-to-workspace.com
+user1-dev	     my-devworkspace       workspacedf64e4a492cd4701   Starting   Waiting for workspace deployment
 ----
+====
+
+. When the workspace starts with the *PHASE* status *Running*, open the workspace by either way:
+** Visit the URL provided in the `INFO` section of the output from `{orch-cli} get devworkspaces`.
+** Open the workspace from the {prod-short} dashboard.
++
+.Output
+====
+[subs="+quotes,attributes"]
+----
+NAMESPACE            NAME                  DEVWORKSPACE ID             PHASE      INFO
+user1-dev	     my-devworkspace       workspacedf64e4a492cd4701   Running    https://url-to-workspace.com
+----
+====

--- a/modules/end-user-guide/partials/proc_listing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_listing-workspaces.adoc
@@ -2,28 +2,33 @@
 [id="listing-workspaces"]
 = Listing all workspaces
 
-Run the following command to list all workspaces for all users.
+You can list your workspaces on a command line.
 
+.Procedure
+
+* To list your workspaces, enter the following on a command line:
++
 [source,subs="+attributes"]
 ----
 $ {orch-cli} get devworkspaces
-
+----
++
+.Output
+====
+----
 NAMESPACE   NAME                 DEVWORKSPACE ID             PHASE     INFO
+user1-dev   spring-petclinic     workspace6d99e9ffb9784491   Running   https://url-to-workspace.com
 user1-dev   golang-example       workspacedf64e4a492cd4701   Stopped   Stopped
-user1-dev   php-symfony          workspace5a8f37a0a0d94ea3   Stopped   Stopped
+user1-dev   python-hello-world   workspace69c26884bbc141f2   Failed    Container tooling has state CrashLoopBackOff
 ----
+====
 
-TIP: You can add the `--watch` flag to view updates when the workspace's `PHASE` changes.
+[TIP]
+====
+You can view `PHASE` changes live by adding the `--watch` flag to this command.
+====
 
-Admins can add the `--all-namespaces` flag to list all workspaces from all users.
-
-[source,subs="+attributes"]
-----
-$ {orch-cli} get devworkspaces --all-namespaces
-
-NAMESPACE   NAME                 DEVWORKSPACE ID             PHASE     INFO
-user1-dev   golang-example       workspacedf64e4a492cd4701   Stopped   Stopped
-user1-dev   php-symfony          workspace5a8f37a0a0d94ea3   Stopped   Stopped
-user2-dev   python-hello-world   workspace69c26884bbc141f2   Failed    Container tooling has state CrashLoopBackOff
-user3-dev   spring-petclinic     workspace6d99e9ffb9784491   Running   https://url-to-workspace.com
-----
+[NOTE]
+====
+Users with administrative permissions on the cluster can list all workspaces from all {prod-short} users by including the `--all-namespaces` flag.
+====

--- a/modules/end-user-guide/partials/proc_listing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_listing-workspaces.adoc
@@ -4,6 +4,29 @@
 
 You can list your workspaces on a command line.
 
+.Prerequisites
+
+* An active `{orch-cli}` session on the cluster. See {orch-cli-link}.
+
+* You know the relevant {prod-short} user namespace on the cluster.
++
+TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your {prod-short} user namespace as `name`.
+
+* You are on the {prod-short} user namespace on the cluster.
++
+[TIP]
+====
+On OpenShift:
+
+* You can use the `oc` command-line tool to check your current namespace:
++
+`$ oc project`
+
+* You can switch to your {prod-short} user namespace on a command line if needed:
++
+`$ oc project __<user_namespace>__`
+====
+
 .Procedure
 
 * To list your workspaces, enter the following on a command line:
@@ -25,7 +48,7 @@ user1-dev   python-hello-world   workspace69c26884bbc141f2   Failed    Container
 
 [TIP]
 ====
-You can view `PHASE` changes live by adding the `--watch` flag to this command.
+You can view *PHASE* changes live by adding the `--watch` flag to this command.
 ====
 
 [NOTE]

--- a/modules/end-user-guide/partials/proc_removing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_removing-workspaces.adoc
@@ -4,9 +4,14 @@
 
 Removing a workspace only requires deleting the `DevWorkspace` custom resource.
 
-Deleting the `DevWorkspace` custom resource will also delete other workspace resources if they were created by {prod-short} such as the referenced `DevWorkspaceTemplate` and per-workspace `PersistentVolumeClaims`.
+TIP: Remove workspaces by using the {prod-short} dashboard whenever possible.
 
+WARNING: Deleting the `DevWorkspace` custom resource will also delete other workspace resources if they were created by {prod-short} such as the referenced `DevWorkspaceTemplate` and per-workspace `PersistentVolumeClaims`.
+
+.Procedure
+
+* To remove a workspace, run the following command
 [source,subs="+attributes"]
 ----
-$ {orch-cli} delete devworkspace NAME -n NAMESPACE
+$ {orch-cli} delete devworkspace __<workspace_name>__ -n __<user_namespace>__
 ----

--- a/modules/end-user-guide/partials/proc_removing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_removing-workspaces.adoc
@@ -2,16 +2,19 @@
 [id="removing-workspaces"]
 = Removing workspaces
 
-Removing a workspace only requires deleting the `DevWorkspace` custom resource.
+You can remove a workspace by simply deleting the `DevWorkspace` custom resource.
+
+WARNING: Deleting the `DevWorkspace` custom resource will also delete other workspace resources if they were created by {prod-short}: for example, the referenced `DevWorkspaceTemplate` and per-workspace `PersistentVolumeClaims`.
 
 TIP: Remove workspaces by using the {prod-short} dashboard whenever possible.
 
-WARNING: Deleting the `DevWorkspace` custom resource will also delete other workspace resources if they were created by {prod-short} such as the referenced `DevWorkspaceTemplate` and per-workspace `PersistentVolumeClaims`.
-
 .Procedure
 
-* To remove a workspace, run the following command
-[source,subs="+attributes"]
+. Get the `__<workspace_name>__` of the workspace to remove and the `__<user_namespace>__`.
+
+* Run the following command to remove the workspace:
++
+[subs="+quotes,attributes"]
 ----
 $ {orch-cli} delete devworkspace __<workspace_name>__ -n __<user_namespace>__
 ----

--- a/modules/end-user-guide/partials/proc_removing-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_removing-workspaces.adoc
@@ -8,9 +8,39 @@ WARNING: Deleting the `DevWorkspace` custom resource will also delete other work
 
 TIP: Remove workspaces by using the {prod-short} dashboard whenever possible.
 
-.Procedure
+.Prerequisites
 
-. Get the `__<workspace_name>__` of the workspace to remove and the `__<user_namespace>__`.
+* An active `{orch-cli}` session on the cluster. See {orch-cli-link}.
+
+* You know the workspace name.
++
+[TIP]
+====
+You can find the relevant workspace name in the output of the following command:
+
+`$ {orch-cli} get devworkspaces`
+====
+
+* You know the relevant {prod-short} user namespace on the cluster.
++
+TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your {prod-short} user namespace as `name`.
+
+* You are on the {prod-short} user namespace on the cluster.
++
+[TIP]
+====
+On OpenShift:
+
+* You can use the `oc` command-line tool to check your current namespace:
++
+`$ oc project`
+
+* You can switch to your {prod-short} user namespace on a command line if needed:
++
+`$ oc project __<user_namespace>__`
+====
+
+.Procedure
 
 * Run the following command to remove the workspace:
 +

--- a/modules/end-user-guide/partials/proc_starting-stopped-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_starting-stopped-workspaces.adoc
@@ -2,15 +2,45 @@
 [id="starting-stopped-workspaces"]
 = Starting stopped workspaces
 
-You can start a stopped workspace by setting the `spec.started` field in the `Devworkspace` to `true`.
+You can start a stopped workspace by setting the `spec.started` field in the `Devworkspace` custom resource to `true`.
+
+.Prerequisites
+
+* An active `{orch-cli}` session on the cluster. See {orch-cli-link}.
+
+* You know the workspace name.
++
+[TIP]
+====
+You can find the relevant workspace name in the output of the following command:
+
+`$ {orch-cli} get devworkspaces`
+====
+
+* You know the relevant {prod-short} user namespace on the cluster.
++
+TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your {prod-short} user namespace as `name`.
+
+* You are on the {prod-short} user namespace on the cluster.
++
+[TIP]
+====
+On OpenShift:
+
+* You can use the `oc` command-line tool to check your current namespace:
++
+`$ oc project`
+
+* You can switch to your {prod-short} user namespace on a command line if needed:
++
+`$ oc project __<user_namespace>__`
+====
 
 .Procedure
 
-. Get the `__<workspace_name>__` of the stopped workspace and the `__<user_namespace>__`.
-
-. Run the following command to start the stopped workspace:
+* Run the following command to start the stopped workspace:
 +
-[source,subs="+attributes"]
+[subs="+quotes,attributes"]
 ----
 $ {orch-cli} patch devworkspace __<workspace_name>__ -p '{"spec":{"started":true}}' --type=merge -n __<user_namespace>__ && \
         {orch-cli} wait --for=jsonpath='{.status.phase}'=Running dw/__<workspace_name>__ -n __<user_namespace>__

--- a/modules/end-user-guide/partials/proc_starting-stopped-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_starting-stopped-workspaces.adoc
@@ -2,14 +2,16 @@
 [id="starting-stopped-workspaces"]
 = Starting stopped workspaces
 
-A stopped workspace can be started by setting the `Devworkspace` 's `spec.started` field to `true`.
+You can start a stopped workspace by setting the `spec.started` field in the `Devworkspace` to `true`.
 
-To use the `wait` command to wait for the status change, a minimum version of `1.23` for `kubectl`, or a minimum version of `4.10` for `oc` is required.
+.Procedure
 
-After determining the `NAME` and `NAMESPACE` of the workspace to start, run:
+. Get the `__<workspace_name>__` of the stopped workspace and the `__<user_namespace>__`.
 
+. Run the following command to start the stopped workspace:
++
 [source,subs="+attributes"]
 ----
-$ {orch-cli} patch devworkspace NAME -p '{"spec":{"started":true}}' --type=merge -n NAMESPACE && \
-        {orch-cli} wait --for=jsonpath='{.status.phase}'=Running dw/NAME -n NAMESPACE
+$ {orch-cli} patch devworkspace __<workspace_name>__ -p '{"spec":{"started":true}}' --type=merge -n __<user_namespace>__ && \
+        {orch-cli} wait --for=jsonpath='{.status.phase}'=Running dw/__<workspace_name>__ -n __<user_namespace>__
 ----

--- a/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
@@ -2,14 +2,16 @@
 [id="stopping-workspaces"]
 = Stopping workspaces
 
-A workspace can be stopped by setting the `Devworkspace` 's `spec.started` field to `false`.
+You can stop a workspace by setting the `spec.started` field in the `Devworkspace` to `false`.
 
-To use the `wait` command to wait for the status change, a minimum version of `1.23` for `kubectl`, or a minimum version of `4.10` for `oc` is required.
+.Procedure
 
-After determining the `NAME` and `NAMESPACE` of the workspace to stop, run:
+. Get the `__<workspace_name>__` of the workspace to stop and the `__<user_namespace>__`.
 
+. Run the following command to stop that workspace:
++
 [source,subs="+attributes"]
 ----
-$ {orch-cli} patch devworkspace NAME -p '{"spec":{"started":false}}' --type=merge -n NAMESPACE && \
-        {orch-cli} wait --for=jsonpath='{.status.phase}'=Stopped dw/NAME -n NAMESPACE
+$ {orch-cli} patch devworkspace __<workspace_name>__ -p '{"spec":{"started":false}}' --type=merge -n __<user_namespace>__ && \
+        {orch-cli} wait --for=jsonpath='{.status.phase}'=Stopped dw/__<workspace_name>__ -n __<user_namespace>__
 ----

--- a/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
+++ b/modules/end-user-guide/partials/proc_stopping-workspaces.adoc
@@ -2,15 +2,45 @@
 [id="stopping-workspaces"]
 = Stopping workspaces
 
-You can stop a workspace by setting the `spec.started` field in the `Devworkspace` to `false`.
+You can stop a workspace by setting the `spec.started` field in the `Devworkspace` custom resource to `false`.
+
+.Prerequisites
+
+* An active `{orch-cli}` session on the cluster. See {orch-cli-link}.
+
+* You know the workspace name.
++
+[TIP]
+====
+You can find the relevant workspace name in the output of the following command:
+
+`$ {orch-cli} get devworkspaces`
+====
+
+* You know the relevant {prod-short} user namespace on the cluster.
++
+TIP: You can visit `pass:c,a,q[{prod-url}]/api/kubernetes/namespace` to get your {prod-short} user namespace as `name`.
+
+* You are on the {prod-short} user namespace on the cluster.
++
+[TIP]
+====
+On OpenShift:
+
+* You can use the `oc` command-line tool to check your current namespace:
++
+`$ oc project`
+
+* You can switch to your {prod-short} user namespace on a command line if needed:
++
+`$ oc project __<user_namespace>__`
+====
 
 .Procedure
 
-. Get the `__<workspace_name>__` of the workspace to stop and the `__<user_namespace>__`.
-
-. Run the following command to stop that workspace:
+* Run the following command to stop that workspace:
 +
-[source,subs="+attributes"]
+[subs="+quotes,attributes"]
 ----
 $ {orch-cli} patch devworkspace __<workspace_name>__ -p '{"spec":{"started":false}}' --type=merge -n __<user_namespace>__ && \
         {orch-cli} wait --for=jsonpath='{.status.phase}'=Stopped dw/__<workspace_name>__ -n __<user_namespace>__


### PR DESCRIPTION
<!-- 
Please use one of the following prefixes for the title:
docs: Documentation not including procedures. Engineering review is mandatory.
procedures: Documentation including procedures. Testing procedures is mandatory. Engineering and QE review is mandatory (Engineering can review on behalf of QE). 
chore: Routine, release, tooling, version upgrades.
fix: Fix build, language, links, or metadata.
-->

<!-- Read our [Contribution guide](https://github.com/eclipse/che-docs/blob/master/CONTRIBUTING.adoc) before submitting a PR. -->

## What does this pull request change?
Review and edit https://github.com/eclipse-che/che-docs/pull/2510

## What issues does this pull request fix or reference?
https://issues.redhat.com/browse/RHDEVDOCS-3216
https://issues.redhat.com/browse/RHDEVDOCS-4093

## Specify the version of the product this pull request applies to
See https://github.com/eclipse-che/che-docs/pull/2510

## Pull Request checklist

The author and the reviewers validate the content of this pull request with the following checklist, in addition to the [automated tests](code_review_checklist.adoc).

- Any procedure:
  - [ ] Successfully tested.
- Any page or link rename:
  - [ ] The page contains a redirection for the previous URL.
  - Propagate the URL change in:
    - [ ] Dashboard [default branding data](https://github.com/eclipse-che/che-dashboard/blob/main/packages/dashboard-frontend/src/services/bootstrap/branding.constant.ts)
    - [ ] Chectl [constants.ts](https://github.com/che-incubator/chectl/blob/master/src/constants.ts)
- [ ] Builds on [Eclipse Che hosted by Red Hat](https://workspaces.openshift.com).
- [ ] the *`Validate language on files added or modified`* step reports no vale warnings.
